### PR TITLE
Actually use docker to deploy and not only to build.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 LICENCE
 README.md
 .gitignore
-Dockerfile*
 *.swp
 */*.swp
+Dockerfile.build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
-FROM heroku/cedar
+FROM scratch
 
 COPY url-shortener /app/user/
-RUN mkdir -p /app/user/public
+COPY ca-certificates.crt /etc/ssl/certs/
 ADD public /app/user/public
+
+WORKDIR /app/user
+
+EXPOSE 5000
+
+ENTRYPOINT ["/app/user/url-shortener"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,3 +1,30 @@
-FROM golang:1-onbuild
+# This is the build Dockerfile: it creates an image where we can build the Go
+# binary as well as the release Docker container. It is OK to add many
+# dependencies as needed to compile properly as they won't be released in the
+# final image.
+FROM golang:1.6
 
-EXPOSE 5000
+RUN apt-get update -qq
+RUN apt-get install -qqy ca-certificates curl
+
+# Install Docker from Docker Inc. repositories.
+RUN curl -sSL https://get.docker.com/ | sh
+
+RUN mkdir -p /go/src/app
+WORKDIR /go/src/app
+
+COPY . /go/src/app
+RUN cp /etc/ssl/certs/ca-certificates.crt /go/src/app
+
+RUN go-wrapper download
+RUN go-wrapper install
+RUN go test
+
+ENV CGO_ENABLED=0
+RUN go build -ldflags "-s" -a -installsuffix cgo -o url-shortener
+
+VOLUME /var/lib/docker
+
+# NOTE: to run Docker inside a Docker container, you should pass the docker
+# socket with -v /var/run/docker.sock:/var/run/docker.sock
+CMD docker build -f Dockerfile -t "${CONTAINER_TAG}" .

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To create clean binaries, we use Docker. Install docker, then run
 ./build.sh.
 ```
 
-It will generate a `url-shortener` binary that you can deploy.
+It will generate a docker image `lascap/url-shortener` that you can deploy.
 
 ## Configuration
 

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-readonly IMAGE=$(cat /dev/urandom | tr -cd 'a-f0-9' | head -c 32)
+readonly CONTAINER_NAME="lascap/url-shortener"
+readonly HASH="$(cat /dev/urandom | tr -cd 'a-f0-9' | head -c 10)"
+readonly IMAGE="${CONTAINER_NAME}-build:${HASH}"
 docker build -t "${IMAGE}" -f Dockerfile.build .
 
-readonly CONTAINER=$(docker create "${IMAGE}")
-docker cp "${CONTAINER}":/go/bin/app url-shortener
-docker rm "${CONTAINER}"
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e CONTAINER_TAG="${CONTAINER_NAME}:${HASH}" "${IMAGE}"
+
 docker rmi "${IMAGE}"


### PR DESCRIPTION
Before the build.sh script was only compiling the Go binary, now it also embeds it in a minimal container (7Mb) very easy to deploy.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/pcorpet/url-shortener/9)

<!-- Reviewable:end -->
